### PR TITLE
Fix custom validation not showing message.

### DIFF
--- a/src/assets/js/views/configurator.js
+++ b/src/assets/js/views/configurator.js
@@ -273,7 +273,7 @@ PC.options = PC.options || {};
 				// show errors and prevent adding to cart
 				console.log( errors );
 				var messages = [];
-				_.each( PC.fe.errors, function( error ) {
+				_.each( errors, function( error ) {
 					if ( error.choice ) {
 						error.choice.set( 'has_error', error );
 					}


### PR DESCRIPTION
Adding custom validator and setting errors doesn't work, because it doesn't take into account the errors coming from the filter.